### PR TITLE
fix: publish github aciton

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Publish ${{ matrix.os }}
         uses: taiki-e/upload-rust-binary-action@v1
         with:
-          bin: square
+          bin: tmplrust
           archive: $bin-$tag-$target
           include: LICENSE,README.md
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
       - name: Publish ${{ matrix.os }}
         uses: taiki-e/upload-rust-binary-action@v1
         with:
-          bin: square
+          bin: tmplrust
           target: ${{ matrix.target }}
           archive: $bin-$tag-$target
           include: LICENSE,README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.1.1] - 2023-11-02
+
+### Fixed
+
+- Publish github action
+
 ## [v0.1.0] - 2023-11-02
 
 ### Added
@@ -19,5 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Workflow to publish binaries automatically on release
 - Pull-request template
 
-[unreleased]: https://github.com/yawn77/tmplrust/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/yawn77/tmplrust/compare/v0.1.1...HEAD
+[v0.1.1]: https://github.com/yawn77/tmplrust/compare/v0.1.1...v0.1.0
 [v0.1.0]: https://github.com/yawn77/tmplrust/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "tmplrust"
-version = "0.1.0"
+version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmplrust"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
# Description

## Fixed

- Publish github action

# Checklist

## Always

- [ ] Determine the next version number (e.g., by using [getNextVersion](https://github.com/thenativeweb/get-next-version) when you use conventional commits)
- [ ] Update version number in `Cargo.toml`
- [ ] Update README.md
- [ ] Maintain CHANGELOG.md

## After Merge

- Create a release in GitHub. Make use of your changelog to describe it
